### PR TITLE
Fwi and other download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ branches:
   only:
     - master
 
+dist: xenial
+
 python:
   - "3.5"
   - "3.6"

--- a/fwi_download.py
+++ b/fwi_download.py
@@ -1,0 +1,46 @@
+import logging
+from pathlib import Path
+from pymerra2 import download
+
+# Download Fire Weather indices from the public https NCCS portal.
+# Filenames and path are quite different than the MERRA2 products, thus the different file.
+
+url_template = "https://portal.nccs.nasa.gov/datashare/GlobalFWI/v2.0/fwiCalcs.{data_source}/Default/{prcp_source}/{year:04d}/FWI.{prcp_source}.{freq_str}.Default.{date}.nc"
+
+# Source of tas, rh, ws and snowdepth, either "MERRA2" or "GEOS-5"
+data_source = "MERRA2"
+# Source of precipitation data one of:
+# "CPC", "GPCP", "GPM.EARLY.v5", "GPM.EARLY", "GPM.FINAL.v5", "GPM.FINAL", "GPM.LATE.v5", "MERRA2.CORRECTED", "MERRA", "Sheff", "TRMM"
+prcp_source = "MERRA2.CORRECTED"
+# Wanted frequency either "Daily" or "Monthly"
+freq_str = "Daily"
+
+output_dir = None
+
+for yyyy in range(2017, 2019):
+    for mm in range(1, 13):
+        download.download_from_url(
+            url_template=url_template,
+            var_name="FWI",
+            freq=freq_str.casefold(),
+            initial_year=yyyy,
+            final_year=yyyy,
+            initial_month=mm,
+            final_month=mm,
+            initial_day=1,
+            output_dir="/home/pbourgault/Documents/",
+            delete_temp_dir=True,
+            merra2_names_map={
+                "{0}_{1}".format(prcp_source, ind): ind
+                for ind in ["DC", "DMC", "FFMC", "ISI", "BUI", "FWI", "DSR"]
+            },
+            verbose=True,
+            # All below are kwargs for the url_template or the final attrs
+            data_source=data_source,
+            freq_str=freq_str,
+            prcp_source=prcp_source,
+            Source="GFWED",
+            Title="Global Fire WEather Database",
+            References="https://data.giss.nasa.gov/impacts/gfwed",
+            cell_methods="",
+        )

--- a/fwi_download.py
+++ b/fwi_download.py
@@ -18,28 +18,24 @@ freq_str = "Daily"
 output_dir = None
 
 for yyyy in range(2017, 2019):
-    for mm in range(1, 13):
-        download.download_from_url(
-            url_template=url_template,
-            freq=freq_str.casefold(),
-            initial_year=yyyy,
-            final_year=yyyy,
-            initial_month=mm,
-            final_month=mm,
-            initial_day=1,
-            output_dir="/home/pbourgault/Documents/",
-            delete_temp_dir=True,
-            merra2_names_map={
-                "{0}_{1}".format(prcp_source, ind): ind
-                for ind in ["DC", "DMC", "FFMC", "ISI", "BUI", "FWI", "DSR"]
-            },
-            verbose=True,
-            # All below are kwargs for the url_template or the final attrs
-            data_source=data_source,
-            freq_str=freq_str,
-            prcp_source=prcp_source,
-            Source="GFWED",
-            Title="Global Fire WEather Database",
-            References="https://data.giss.nasa.gov/impacts/gfwed",
-            cell_methods="",
-        )
+    download.download_from_url(
+        url_template=url_template,
+        freq=freq_str.casefold(),
+        initial_year=yyyy,
+        final_year=yyyy,
+        output_dir="/home/pbourgault/Documents/",
+        delete_temp_dir=True,
+        merra2_names_map={
+            "{0}_{1}".format(prcp_source, ind): ind
+            for ind in ["DC", "DMC", "FFMC", "ISI", "BUI", "FWI", "DSR"]
+        },
+        verbose=True,
+        # All below are kwargs for the url_template or the final attrs
+        data_source=data_source,
+        freq_str=freq_str,
+        prcp_source=prcp_source,
+        Source="GFWED",
+        Title="Global Fire WEather Database",
+        References="https://data.giss.nasa.gov/impacts/gfwed",
+        cell_methods="",
+    )

--- a/fwi_download.py
+++ b/fwi_download.py
@@ -21,7 +21,6 @@ for yyyy in range(2017, 2019):
     for mm in range(1, 13):
         download.download_from_url(
             url_template=url_template,
-            var_name="FWI",
             freq=freq_str.casefold(),
             initial_year=yyyy,
             final_year=yyyy,

--- a/pymerra2/__init__.py
+++ b/pymerra2/__init__.py
@@ -1,11 +1,10 @@
 __version__ = 0.3
-__title__ = 'pymerra2'
-__description__ = 'A tool for downloading and subsetting NASA MERRA-2 Data'
-__url__ = 'https://github.com/Ouranosinc/pymerra2'
-__author__ = 'Trevor James Smith'
-__author_email__ = 'smith.trevorj@ouranos.ca'
-__license__ = 'Apache 2.0'
-__copyright__ = 'Copyright 2018 Ouranos Inc.'
+__title__ = "pymerra2"
+__description__ = "A tool for downloading and subsetting NASA MERRA-2 Data"
+__url__ = "https://github.com/Ouranosinc/pymerra2"
+__author__ = "Trevor James Smith"
+__author_email__ = "smith.trevorj@ouranos.ca"
+__license__ = "Apache 2.0"
+__copyright__ = "Copyright 2018 Ouranos Inc."
 
 from pymerra2 import download, variables
-

--- a/pymerra2/download.py
+++ b/pymerra2/download.py
@@ -755,7 +755,7 @@ def daily_netcdf(
         esdt_dir, collection, merra_name, standard_name,
         see the Bosilovich paper for details.
         May also contain the following netCDF attributes:
-        Title, Institution, Referece, Source
+        Title, Institution, Reference, Source
     verbose : bool
 
     Notes
@@ -1160,7 +1160,7 @@ def download_from_url(
         Whether to delete the temporary download directory or not.
     verbose : bool,
         Whether to print statuses to the screen, or not.
-    
+
     All other kwargs are passed to the url formatting and to the merging function.
     In the latter, they might be attributes missing in the files restricted to:
         Title, Institution, Source, Reference
@@ -1178,12 +1178,9 @@ def download_from_url(
     if (2, 7) < sys.version_info < (3, 6):
         output_dir = str(output_dir)
 
-    init_date = datetime.datetime.fromisoformat(
-        initial_year, initial_month, initial_day
-    )
-    end_date = datetime.datetime.fromisoformat(
-        final_year, final_month, final_day or monthrange(initial_year, initial_month)[1]
-    )
+    init_date = datetime.datetime(initial_year, initial_month, initial_day)
+    end_date = datetime.datetime(final_year, final_month, final_day or monthrange(initial_year, initial_month)[1])
+
     temp_dir_download = tempfile.mkdtemp(dir=output_dir)
 
     for date, year in _date_range_gen(init_date, end_date, freq=freq):

--- a/pymerra2/download.py
+++ b/pymerra2/download.py
@@ -2,6 +2,7 @@ import datetime
 import shutil
 import subprocess
 import sys
+import glob
 import tempfile
 from calendar import monthrange
 from pathlib import Path
@@ -84,6 +85,13 @@ def _datetimes_to_time_vectors(
     except (AttributeError, TypeError):
         time_tuples = datetimes.timetuple()
         return _time_vectors_int(ma.array(time_tuples))
+
+
+def get_nc_attr(nc, name, default=None):
+    try:
+        return nc.getncattr(name)
+    except AttributeError:
+        return default
 
 
 def fixed_netcdf(
@@ -342,7 +350,12 @@ def subdaily_netcdf(
     for nc_file in nc_files:
         yyyy = int(nc_file.split(".")[-2][0:4])
         mm = int(nc_file.split(".")[-2][4:6])
-        if (yyyy >= initial_year) and (yyyy <= final_year) and (mm >= initial_month) and (mm <= final_month):
+        if (
+            (yyyy >= initial_year)
+            and (yyyy <= final_year)
+            and (mm >= initial_month)
+            and (mm <= final_month)
+        ):
             relevant_files.append(nc_file)
             nc = netCDF4.Dataset(nc_file, "r")
             ncvar = nc.variables[merra2_var_dict["merra_name"]]
@@ -624,7 +637,7 @@ def subdaily_download_and_convert(
     output_dir: Union[str, Path] = None,
     delete_temp_dir: bool = False,
     verbose: bool = False,
-    time_frequency: str = "1hr"
+    time_frequency: str = "1hr",
 ):
     """MERRA2 subdaily download and conversion.
 
@@ -715,11 +728,12 @@ def subdaily_download_and_convert(
 
 
 def daily_netcdf(
-    path_data: Union[str, Path],
+    path_data: Union[str, Path, List[str]],
     output_file: Union[str, Path],
     var_name: str,
     initial_year: int,
     final_year: int,
+    time_from_filename: bool = False,
     merra2_var_dict: Optional[dict] = None,
     verbose: bool = False,
 ):
@@ -745,14 +759,17 @@ def daily_netcdf(
     perhaps not an ideal separation as this is duplicated code...
 
     """
-    if not isinstance(path_data, Path):
-        path_data = Path(path_data)
+    if isinstance(path_data, list):
+        nc_files = path_data
+    else:
+        if not isinstance(path_data, Path):
+            path_data = Path(path_data)
 
-    if not merra2_var_dict:
-        merra2_var_dict = var_list[var_name]
+        if not merra2_var_dict:
+            merra2_var_dict = var_list[var_name]
 
-    search_str = "*{0}*.nc4".format(merra2_var_dict["collection"])
-    nc_files = [str(f) for f in path_data.rglob(search_str)]
+        search_str = "*{0}*.nc4".format(merra2_var_dict["collection"])
+        nc_files = [str(f) for f in path_data.rglob(search_str)]
     nc_files.sort()
 
     relevant_files = []
@@ -791,8 +808,9 @@ def daily_netcdf(
     nc1.Conventions = "CF-1.7"
 
     # 2.6.2. Description of file contents
-    nc1.title = (
-        "Modern-Era Retrospective analysis for Research and " "Applications, Version 2"
+    nc1.title = merra2_var_dict.get(
+        "Title",
+        "Modern-Era Retrospective analysis for Research and Applications, Version 2",
     )
     if (len(divided_files) == 1) and (len(divided_files[0]) == 1):
         nc1.history = (
@@ -805,9 +823,26 @@ def daily_netcdf(
             "Extract variable & "
             "Merge in time."
         ).format(nc_reference.History, now, __version__)
-    nc1.institution = nc_reference.Institution
-    nc1.source = "Reanalysis"
-    nc1.references = nc_reference.References
+
+    nc1.institution = get_nc_attr(
+        nc_reference,
+        "Institution",
+        get_nc_attr(
+            nc_reference,
+            "Center",
+            merra2_var_dict.get(
+                "Institution", "NASA Global Modeling and Assimilation Office"
+            ),
+        ),
+    )
+    nc1.source = get_nc_attr(
+        nc_reference, "Source", merra2_var_dict.get("Source", "Reanalysis")
+    )
+    nc1.references = get_nc_attr(
+        nc_reference,
+        "References",
+        merra2_var_dict.get("References", "http://gmao.gsfc.nasa.gov"),
+    )
 
     # Using lower case c for conventions because lower() is used below...
     attr_overwrite = ["conventions", "title", "institution", "source", "references"]
@@ -920,8 +955,18 @@ def daily_netcdf(
                 print(nc_file)
             nc = netCDF4.Dataset(nc_file, "r")
             ncvar = nc.variables[merra2_var_dict["merra_name"]]
-            nctime = nc.variables["time"]
-            ncdatetime = netCDF4.num2date(nctime[:], nctime.units)
+            if time_from_filename:
+                dt_str = nc_file.split(".")[-2]
+                if len(dt_str) == 6:
+                    dt_str += "01"
+                ncdatetime = [
+                    datetime.datetime(
+                        int(dt_str[:4]), int(dt_str[4:6]), int(dt_str[6:])
+                    )
+                ]
+            else:
+                nctime = nc.variables["time"]
+                ncdatetime = netCDF4.num2date(nctime[:], nctime.units)
             nctime_1980 = np.round(netCDF4.date2num(ncdatetime, time.units))
             tmp_data[ttmp : ttmp + ncvar.shape[0], :, :] = ncvar[:, :, :]
             tmp_time[ttmp : ttmp + ncvar.shape[0]] = nctime_1980[:]
@@ -1040,3 +1085,129 @@ def daily_download_and_convert(
         )
     if delete_temp_dir:
         shutil.rmtree(temp_dir_download)
+
+
+def _date_range_gen(
+    init: datetime.datetime, end: datetime.datetime, freq: str = "daily"
+):
+    for year in range(init.year, end.year + 1):
+        for month in range(
+            init.month if year == init.year else 1,
+            end.month + 1 if year == end.year else 13,
+        ):
+            if freq == "daily":
+                init_day = (
+                    init.day if (year == init.year) and (month == init.month) else 1
+                )
+                end_day = (
+                    end.day
+                    if (year == end.year) and (month == end.month)
+                    else monthrange(year, month)[1]
+                )
+                for day in range(init_day, end_day + 1):
+                    yield "{yyyy}{mm:02d}{dd:02d}".format(
+                        yyyy=year, mm=month, dd=day
+                    ), year
+            elif freq == "monthly":
+                yield "{yyyy}{mm:02d}".format(yyyy=year, mm=month), year
+
+
+def download_from_url(
+    url_template: str,
+    var_name: str,
+    freq: str,
+    initial_year: int,
+    final_year: int,
+    initial_month: int = 1,
+    final_month: int = 12,
+    initial_day: int = 1,
+    final_day: Optional[int] = None,
+    output_dir: Union[str, Path] = None,
+    delete_temp_dir: bool = True,
+    merra2_names_map: Optional[dict] = None,
+    verbose: bool = True,
+    **kwargs
+):
+    if isinstance(output_dir, Path):
+        output_dir = Path(output_dir)
+    if output_dir is None:
+        output_dir = Path.cwd()
+
+    if (2, 7) < sys.version_info < (3, 6):
+        output_dir = str(output_dir)
+
+    init_date = datetime.datetime.fromisoformat(
+        initial_year, initial_month, initial_day
+    )
+    end_date = datetime.datetime.fromisoformat(
+        final_year, final_month, final_day or monthrange(initial_year, initial_month)[1]
+    )
+    temp_dir_download = tempfile.mkdtemp(dir=output_dir)
+
+    for date, year in _date_range_gen(init_date, end_date, freq=freq):
+        subprocess.call(
+            [
+                "wget",
+                "-c",
+                "--directory-prefix={0}".format(temp_dir_download),
+                "--load-cookies",
+                str(Path("~/.urs_cookies").expanduser()),
+                "--save-cookies",
+                str(Path("~/.urs_cookies").expanduser()),
+                "--keep-session-cookies",
+                url_template.format(date=date, year=year, freq=freq, **kwargs),
+            ]
+        )
+
+    nc_files = glob.glob(str(Path(temp_dir_download) / "*.nc"))
+    nc_reference = netCDF4.Dataset(nc_files[0], "r")
+
+    merra2_names_map = merra2_names_map or {}
+    var_names = []
+    merra2_var_dicts = []
+    for var_name, variable in nc_reference.variables.items():
+        if (merra2_names_map and var_name in merra2_names_map) or (
+            var_name not in ["lat", "lon", "time"]
+        ):
+            var_names.append(merra2_names_map.get(var_name, var_name))
+            merra2_var_dicts.append(
+                dict(
+                    merra_name=var_name,
+                    standard_name=merra2_names_map.get(var_name, var_name),
+                    **kwargs
+                )
+            )
+
+    try:
+        netCDF4.num2date(nc_reference["time"][:], nc_reference["time"].units)
+    except ValueError:
+        time_from_filename = True
+    else:
+        time_from_filename = False
+
+    nc_reference.close()
+
+    for var_name, merra2_var_dict in zip(var_names, merra2_var_dicts):
+        out_file_name = file_namer(
+            var_name,
+            "day" if freq == "daily" else "month",
+            initial_year,
+            final_year,
+            initial_month,
+            final_month,
+            initial_day,
+            final_day,
+        )
+        out_file = Path(output_dir).joinpath(out_file_name)
+
+        daily_netcdf(
+            nc_files,
+            output_file=out_file,
+            var_name=var_name,
+            initial_year=initial_year,
+            final_year=final_year,
+            merra2_var_dict=merra2_var_dict,
+            time_from_filename=time_from_filename,
+            verbose=verbose,
+        )
+    return temp_dir_download, out_file

--- a/pymerra2/variables.py
+++ b/pymerra2/variables.py
@@ -139,6 +139,13 @@ var_list = {
         "standard_name": "sea_ice_area_fraction",
         "cell_methods": "time: mean",
     },
+    "snd": {
+        "esdt_dir": "M2T1NXLND.5.12.4",
+        "collection": "tavg1_2d_lnd_Nx",
+        "merra_name": "SNODP",
+        "standard_name": "surface_snow_thickness",
+        "cell_methods": "time: mean",
+    },
     "snw": {
         "esdt_dir": "M2T1NXLND.5.12.4",
         "collection": "tavg1_2d_lnd_Nx",

--- a/scripts/fwi_download.py
+++ b/scripts/fwi_download.py
@@ -1,16 +1,19 @@
-import logging
 from pathlib import Path
 from pymerra2 import download
+
+download_dir = Path.cwd().joinpath("downloaded")
 
 # Download Fire Weather indices from the public https NCCS portal.
 # Filenames and path are quite different than the MERRA2 products, thus the different file.
 
-url_template = "https://portal.nccs.nasa.gov/datashare/GlobalFWI/v2.0/fwiCalcs.{data_source}/Default/{prcp_source}/{year:04d}/FWI.{prcp_source}.{freq_str}.Default.{date}.nc"
+url_template = "https://portal.nccs.nasa.gov/datashare/GlobalFWI/v2.0/fwiCalcs.{data_source}/Default/{prcp_source}/" \
+               "{year:04d}/FWI.{prcp_source}.{freq_str}.Default.{date}.nc "
 
 # Source of tas, rh, ws and snowdepth, either "MERRA2" or "GEOS-5"
 data_source = "MERRA2"
 # Source of precipitation data one of:
-# "CPC", "GPCP", "GPM.EARLY.v5", "GPM.EARLY", "GPM.FINAL.v5", "GPM.FINAL", "GPM.LATE.v5", "MERRA2.CORRECTED", "MERRA", "Sheff", "TRMM"
+# "CPC", "GPCP", "GPM.EARLY.v5", "GPM.EARLY", "GPM.FINAL.v5", "GPM.FINAL",
+# "GPM.LATE.v5", "MERRA2.CORRECTED", "MERRA", "Sheff", "TRMM"
 prcp_source = "MERRA2.CORRECTED"
 # Wanted frequency either "Daily" or "Monthly"
 freq_str = "Daily"
@@ -23,7 +26,7 @@ for yyyy in range(2017, 2019):
         freq=freq_str.casefold(),
         initial_year=yyyy,
         final_year=yyyy,
-        output_dir="/home/pbourgault/Documents/",
+        output_dir=download_dir,
         delete_temp_dir=True,
         merra2_names_map={
             "{0}_{1}".format(prcp_source, ind): ind
@@ -35,7 +38,7 @@ for yyyy in range(2017, 2019):
         freq_str=freq_str,
         prcp_source=prcp_source,
         Source="GFWED",
-        Title="Global Fire WEather Database",
+        Title="Global Fire Weather Database",
         References="https://data.giss.nasa.gov/impacts/gfwed",
         cell_methods="",
     )

--- a/scripts/merra2_subdaily_download.py
+++ b/scripts/merra2_subdaily_download.py
@@ -43,28 +43,3 @@ for yyyy in range(2017, 2019):
             msg = "{}: File not found".format(e)
             logging.error(msg)
             continue
-
-# for v in var_names:
-#     for yyyy in range(2017, 2019):
-#         for mm in range(1, 13):
-#
-#             out_file_name = download.file_namer(v, time_frequency, yyyy, yyyy, mm, mm,)
-#             try:
-#
-#                 download.subdaily_netcdf(
-#                     path_data=download_dir,
-#                     output_file=out_file_name,
-#                     var_name=v,
-#                     initial_year=yyyy,
-#                     final_year=yyyy,
-#                     initial_month=mm,
-#                     final_month=mm,
-#                     merra2_var_dict=None,
-#                     verbose=False,
-#                 )
-#
-#             except Exception as e:
-#                 msg = "{}: File not found".format(e)
-#                 logging.error(msg)
-#                 continue
-

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
 about = dict(
-    __version__=0.3,
+    __version__=0.4,
     __title__="pymerra2",
     __description__="A tool for downloading and repackaging NASA MERRA-2 Data",
     __url__="https://github.com/Ouranosinc/pymerra2",


### PR DESCRIPTION
Fixes nothing
Docs added
No tests added

I added a script to download the publicly available data for the Fire Weather Index of the GFWED from the Nasa/Giss website.
Doing so, I added a `download_from_url`  function. It takes an url template (with many `{ }`) and downloads every file in a range by formatting the url with a date (and other stuff if needed). As those files might have more than one variable, it merges each variable in its own file, as to follow the convention.

The FWI files are a bit different than the raw merra2 netCDFs, so I had to modify the `daily_netcdf`function. I added some way to pass nc attributes that might be missing and to take timestamps from the filename instead of the file itself (why isn't time stored in the FWI files? idk).

`download_from_url` specifically calls `daily_netcdf`, so I didn't copy those changes to `subdaily_netcdf`. Should I?
